### PR TITLE
fix(api): change imageUrl to imageKey

### DIFF
--- a/openapi/components/artworks-images/request.yaml
+++ b/openapi/components/artworks-images/request.yaml
@@ -4,3 +4,6 @@ UploadArtworkImageRequest:
     image:
       type: string
       format: binary
+      description: 업로드할 작품 이미지 파일의 바이너리 문자열
+  required:
+    - image

--- a/openapi/components/artworks-images/response.yaml
+++ b/openapi/components/artworks-images/response.yaml
@@ -1,6 +1,8 @@
 UploadArtworkImageResponse:
   type: object
   properties:
-    imageUrl:
+    imageKey:
       type: string
-      description: 업로드한 작품 이미지의 공개 URL
+      description: S3에 저장된 이미지의 키 값
+  required:
+    - imageKey

--- a/openapi/components/artworks/base.yaml
+++ b/openapi/components/artworks/base.yaml
@@ -5,10 +5,6 @@ ArtworkBase:
     title:
       type: string
       description: 게임 제목
-    imageUrl:
-      type: string
-      format: uri
-      description: 팬아트 작품 이미지 URL
     createdAt:
       type: string
       format: date-time

--- a/openapi/components/artworks/request.yaml
+++ b/openapi/components/artworks/request.yaml
@@ -2,11 +2,14 @@
 CreateArtworkRequest:
   required:
     - title
-    - imageUrl
+    - imageKey
   allOf:
     - $ref: "./base.yaml#/ArtworkBase"
     - type: object
       properties:
+        imageKey:
+          type: string
+          description: S3에 저장된 이미지의 키 값
         genres:
           type: array
           items:
@@ -14,7 +17,7 @@ CreateArtworkRequest:
           description: 게임의 장르명 목록
       example:
         title: "젤다의 전설: 야생의 숨결"
-        imageUrl: "https://example.com/images/botw.jpg"
+        imageKey: "artworks/2024/03/abc123def456"
         createdAt: "2023-05-20T14:45:00Z"
         genres: ["액션", "어드벤처"]
         playedOn: "Switch"

--- a/openapi/components/artworks/response.yaml
+++ b/openapi/components/artworks/response.yaml
@@ -7,6 +7,14 @@ Artwork:
         id:
           type: string
           description: 작품 식별자
+        imageUrl:
+          type: string
+          format: uri
+          description: |
+            팬아트 작품 이미지 URL
+            권한에 따라 다른 형태의 URL이 제공됨
+            - 일반 사용자: 1시간 유효한 서명된 URL
+            - 작품 등록자: 직접 접근 가능한 URL
         genres:
           type: array
           items:

--- a/openapi/output/openapi.json
+++ b/openapi/output/openapi.json
@@ -74,7 +74,7 @@
     },
     "/artworks/images" : {
       "post" : {
-        "description" : "새로운 작품 등록",
+        "description" : "작품 이미지 업로드",
         "operationId" : "uploadArtworkImage",
         "requestBody" : {
           "content" : {
@@ -121,11 +121,6 @@
               "description" : "게임 제목",
               "type" : "string"
             },
-            "imageUrl" : {
-              "description" : "팬아트 작품 이미지 URL",
-              "format" : "uri",
-              "type" : "string"
-            },
             "createdAt" : {
               "description" : "팬아트 작품을 완성한 날짜",
               "format" : "date-time",
@@ -153,6 +148,11 @@
               "description" : "작품 식별자",
               "type" : "string"
             },
+            "imageUrl" : {
+              "description" : "팬아트 작품 이미지 URL\n권한에 따라 다른 형태의 URL이 제공됨\n- 일반 사용자: 1시간 유효한 서명된 URL\n- 작품 등록자: 직접 접근 가능한 URL\n",
+              "format" : "uri",
+              "type" : "string"
+            },
             "genres" : {
               "items" : {
                 "$ref" : "#/components/schemas/getArtworks_200_response_inner_allOf_genres_inner"
@@ -164,7 +164,7 @@
               "type" : "boolean"
             }
           },
-          "required" : [ "genres", "id", "isDraft" ]
+          "required" : [ "genres", "id", "imageUrl", "isDraft" ]
         } ],
         "example" : {
           "id" : "<nanoid format>",
@@ -190,10 +190,12 @@
       "uploadArtworkImage_request" : {
         "properties" : {
           "image" : {
+            "description" : "업로드할 작품 이미지 파일의 바이너리 문자열",
             "format" : "binary",
             "type" : "string"
           }
-        }
+        },
+        "required" : [ "image" ]
       },
       "getArtworks_200_response_inner_allOf_genres_inner" : {
         "allOf" : [ {
@@ -219,22 +221,18 @@
       },
       "uploadArtworkImage_200_response" : {
         "properties" : {
-          "imageUrl" : {
-            "description" : "업로드한 작품 이미지의 공개 URL",
+          "imageKey" : {
+            "description" : "S3에 저장된 이미지의 키 값",
             "type" : "string"
           }
-        }
+        },
+        "required" : [ "imageKey" ]
       },
       "createArtwork_request" : {
         "allOf" : [ {
           "properties" : {
             "title" : {
               "description" : "게임 제목",
-              "type" : "string"
-            },
-            "imageUrl" : {
-              "description" : "팬아트 작품 이미지 URL",
-              "format" : "uri",
               "type" : "string"
             },
             "createdAt" : {
@@ -261,7 +259,7 @@
         }, {
           "example" : {
             "title" : "젤다의 전설: 야생의 숨결",
-            "imageUrl" : "https://example.com/images/botw.jpg",
+            "imageKey" : "artworks/2024/03/abc123def456",
             "createdAt" : "2023-05-20T14:45:00Z",
             "genres" : [ "액션", "어드벤처" ],
             "playedOn" : "Switch",
@@ -269,6 +267,10 @@
             "shortReview" : "광활한 세계와 자유도가 인상적인 걸작"
           },
           "properties" : {
+            "imageKey" : {
+              "description" : "S3에 저장된 이미지의 키 값",
+              "type" : "string"
+            },
             "genres" : {
               "description" : "게임의 장르명 목록",
               "items" : {
@@ -278,7 +280,7 @@
             }
           }
         } ],
-        "required" : [ "imageUrl", "title" ]
+        "required" : [ "imageKey", "title" ]
       },
       "createArtwork_400_response" : {
         "example" : {

--- a/openapi/paths/artworks-images.yaml
+++ b/openapi/paths/artworks-images.yaml
@@ -1,5 +1,5 @@
 post:
-  description: 새로운 작품 등록
+  description: 작품 이미지 업로드
   operationId: uploadArtworkImage
   tags:
     - Artworks


### PR DESCRIPTION
## 관련 이슈
. 

## 작업 내용
- 리스폰스에서 서명된 url 을 사용하기 위해, 기존에 데이터베이스 레코드 등록 시 imageUrl 을 썼던 것을 imageKey 로 다루도록 설계 변경
