### PR TITLE
fix: change success response of github auth callback from 200 to 302

### DIFF
--- a/openapi/components/auth/response.yaml
+++ b/openapi/components/auth/response.yaml
@@ -1,13 +1,3 @@
-# 임시 토큰 리스폰스
-TempTokenResponse:
-  type: object
-  required:
-    - tempToken
-  properties:
-    tempToken:
-      type: string
-      description: 2FA 인증 완료 전까지 사용할 임시 토큰
-
 # 2FA 초기 설정 후 리스폰스
 2FASetupResponse:
   type: object

--- a/openapi/output/openapi.json
+++ b/openapi/output/openapi.json
@@ -34,15 +34,19 @@
         "description" : "GitHub OAuth 콜백 처리",
         "operationId" : "handleGithubOAuthCallback",
         "responses" : {
-          "200" : {
-            "content" : {
-              "application/json" : {
+          "302" : {
+            "description" : "GitHub 인증 성공 및 2FA 페이지로 리다이렉트",
+            "headers" : {
+              "Location" : {
+                "description" : "2FA 페이지 URL (token 과 needToSetup2FA 포함)",
+                "explode" : false,
                 "schema" : {
-                  "$ref" : "#/components/schemas/handleGithubOAuthCallback_200_response"
-                }
+                  "example" : "http://{frontend}/auth/2fa?token={tempToken}&needToSetup2FA={boolean}",
+                  "type" : "string"
+                },
+                "style" : "simple"
               }
-            },
-            "description" : "GitHub 인증 성공 및 2FA 필요"
+            }
           },
           "403" : {
             "content" : {
@@ -676,15 +680,6 @@
             "message" : "너무 많은 요청이 들어왔습니다"
           }
         } ]
-      },
-      "handleGithubOAuthCallback_200_response" : {
-        "properties" : {
-          "tempToken" : {
-            "description" : "2FA 인증 완료 전까지 사용할 임시 토큰",
-            "type" : "string"
-          }
-        },
-        "required" : [ "tempToken" ]
       },
       "setup2FA_201_response" : {
         "properties" : {

--- a/openapi/paths/auth/github/callback/path.yaml
+++ b/openapi/paths/auth/github/callback/path.yaml
@@ -5,12 +5,14 @@ get:
   tags:
     - Auth
   responses:
-    "200":
-      description: GitHub 인증 성공 및 2FA 필요
-      content:
-        application/json:
+    "302":
+      description: GitHub 인증 성공 및 2FA 페이지로 리다이렉트
+      headers:
+        Location:
+          description: 2FA 페이지 URL (token 과 needToSetup2FA 포함)
           schema:
-            $ref: "../../../../components/auth/response.yaml#/TempTokenResponse"
+            type: string
+            example: "http://{frontend}/auth/2fa?token={tempToken}&needToSetup2FA={boolean}"
     "403":
       description: 권한 부재
       content:


### PR DESCRIPTION
## 관련 이슈
- 

## 작업 내용
- 실제 인증 구현과 일치하지 않았던 엔드포인트의 성공 시의 상태 코드 등의 정의를 수정
