### PR TITLE
fix: get rid of bearerAuth from logout path

### DIFF
--- a/openapi/output/openapi.json
+++ b/openapi/output/openapi.json
@@ -298,7 +298,7 @@
                 }
               }
             },
-            "description" : "- Authorization 헤더 누락\n- 유효한 형식이 아닌 토큰\n- 액세스 토큰이 아닌 토큰\n- 리프레시 토큰 쿠키 누락\n"
+            "description" : "- 리프레시 토큰 쿠키 누락\n"
           },
           "401" : {
             "content" : {
@@ -308,12 +308,10 @@
                 }
               }
             },
-            "description" : "- 액세스 토큰 만료\n- 무효한 토큰\n"
+            "description" : "- 만료된 토큰\n- 무효한 토큰\n- 토큰 내 페이로드의 계정 정보가 무효한 경우\n"
           }
         },
         "security" : [ {
-          "bearerAuth" : [ ]
-        }, {
           "cookieAuth" : [ ]
         } ],
         "tags" : [ "Auth" ]

--- a/openapi/paths/auth/logout/path.yaml
+++ b/openapi/paths/auth/logout/path.yaml
@@ -2,7 +2,6 @@ post:
   description: 로그아웃
   operationId: logout
   security:
-    - bearerAuth: []
     - cookieAuth: []
   tags:
     - Auth
@@ -11,9 +10,6 @@ post:
       description: 로그아웃 성공
     "400":
       description: |
-        - Authorization 헤더 누락
-        - 유효한 형식이 아닌 토큰
-        - 액세스 토큰이 아닌 토큰
         - 리프레시 토큰 쿠키 누락
       content:
         application/json:
@@ -21,8 +17,9 @@ post:
             $ref: "../../../components/errors/errors.yaml#/BadRequestError"
     "401":
       description: |
-        - 액세스 토큰 만료
+        - 만료된 토큰
         - 무효한 토큰
+        - 토큰 내 페이로드의 계정 정보가 무효한 경우
       content:
         application/json:
           schema:


### PR DESCRIPTION
## 관련 이슈
- 

## 작업 내용
- 프론트엔드 구현과정에서 어울리지 않는 인증 세큐리티 스킴인 bearerAuth 를 로그아웃으로부터 삭제
