### PR TITLE
fix: redesign get artworks

### DIFF
--- a/openapi/components/artworks/response.yaml
+++ b/openapi/components/artworks/response.yaml
@@ -48,6 +48,41 @@ Artwork:
     shortReview: "광활한 세계와 자유도가 인상적인 걸작"
     isDraft: false
 
+# 페이지네이션 리스폰스용 스키마
+ArtworkListResponse:
+  type: object
+  required:
+    - items
+    - metadata
+  properties:
+    items:
+      type: array
+      items:
+        $ref: "#/Artwork"
+    metadata:
+      type: object
+      required:
+        - totalCount
+        - totalPages
+        - currentPage
+        - pageSize
+      properties:
+        totalCount:
+          type: integer
+          description: 검색 조건에 해당하는 전체 작품 수
+        totalPages:
+          type: integer
+          description: 전체 페이지 수 (totalCount와 pageSize 기반으로 계산)
+        currentPage:
+          type: integer
+          description: 현재 조회 중인 페이지 번호
+        pageSize:
+          type: integer
+          description: |
+            페이지당 항목 수 (고정값)
+            * CMS 접근: 10개
+            * 일반 접근: 20개
+
 # 업로드 이미지 리스폰스용 스키마
 UploadArtworkImageResponse:
   type: object

--- a/openapi/output/openapi.json
+++ b/openapi/output/openapi.json
@@ -319,24 +319,124 @@
     },
     "/artworks" : {
       "get" : {
-        "description" : "작품 목록 취득",
+        "description" : "작품 목록 조회",
         "operationId" : "getArtworks",
+        "parameters" : [ {
+          "description" : "(공통) 페이지 번호 (1부터 시작)",
+          "explode" : true,
+          "in" : "query",
+          "name" : "page",
+          "required" : false,
+          "schema" : {
+            "default" : 1,
+            "minimum" : 1,
+            "type" : "integer"
+          },
+          "style" : "form"
+        }, {
+          "description" : "(공통) 정렬 기준\n* created_desc: 최신순\n* created_asc: 과거순\n* rating_desc: 평점 높은순\n* rating_asc: 평점 낮은순\n",
+          "explode" : true,
+          "in" : "query",
+          "name" : "sort",
+          "required" : false,
+          "schema" : {
+            "default" : "created_desc",
+            "enum" : [ "created_desc", "created_asc", "rating_desc", "rating_asc" ],
+            "type" : "string"
+          },
+          "style" : "form"
+        }, {
+          "description" : "(공통) 플랫폼 필터 (복수 선택 가능)",
+          "explode" : true,
+          "in" : "query",
+          "name" : "platforms",
+          "required" : false,
+          "schema" : {
+            "items" : {
+              "enum" : [ "Steam", "Switch", "GOG", "Epic Games", "Android" ],
+              "type" : "string"
+            },
+            "type" : "array",
+            "uniqueItems" : true
+          },
+          "style" : "form"
+        }, {
+          "description" : "(공통) 장르 필터 (복수 선택 가능)",
+          "explode" : true,
+          "in" : "query",
+          "name" : "genres",
+          "required" : false,
+          "schema" : {
+            "items" : {
+              "type" : "string"
+            },
+            "type" : "array",
+            "uniqueItems" : true
+          },
+          "style" : "form"
+        }, {
+          "description" : "(공통) 제목 검색어\n* 앞뒤 공백은 자동으로 제거됨\n* 연속된 공백은 단일 공백으로 처리됨\n",
+          "explode" : true,
+          "in" : "query",
+          "name" : "search",
+          "required" : false,
+          "schema" : {
+            "maxLength" : 50,
+            "minLength" : 1,
+            "type" : "string"
+          },
+          "style" : "form"
+        }, {
+          "description" : "(CMS) 작품 상태 필터 (인증된 요청에서만 사용 가능)",
+          "explode" : true,
+          "in" : "query",
+          "name" : "status",
+          "required" : false,
+          "schema" : {
+            "default" : [ "published" ],
+            "items" : {
+              "enum" : [ "draft", "published" ],
+              "type" : "string"
+            },
+            "type" : "array"
+          },
+          "style" : "form"
+        } ],
         "responses" : {
           "200" : {
             "content" : {
               "application/json" : {
                 "schema" : {
-                  "items" : {
-                    "$ref" : "#/components/schemas/getArtworks_200_response_inner"
-                  },
-                  "type" : "array"
+                  "$ref" : "#/components/schemas/getArtworks_200_response"
                 }
               }
             },
-            "description" : "작품 목록이 반환됨"
+            "description" : "작품 목록 조회 성공"
+          },
+          "400" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/setup2FA_400_response"
+                }
+              }
+            },
+            "description" : "잘못된 요청"
+          },
+          "401" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/setup2FA_401_response"
+                }
+              }
+            },
+            "description" : "인증 실패"
           }
         },
-        "security" : [ ],
+        "security" : [ {
+          "bearerAuth" : [ ]
+        }, { } ],
         "tags" : [ "Artworks" ]
       },
       "post" : {
@@ -357,7 +457,7 @@
             "content" : {
               "application/json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/getArtworks_200_response_inner"
+                  "$ref" : "#/components/schemas/getArtworks_200_response_items_inner"
                 }
               }
             },
@@ -478,27 +578,113 @@
         },
         "required" : [ "accessToken" ]
       },
-      "getArtworks_200_response_inner_allOf_genres_inner" : {
+      "getArtworks_200_response_items_inner" : {
         "allOf" : [ {
           "properties" : {
-            "name" : {
-              "description" : "장르명",
+            "title" : {
+              "description" : "게임 제목",
+              "type" : "string"
+            },
+            "createdAt" : {
+              "description" : "팬아트 작품을 완성한 날짜",
+              "format" : "date-time",
+              "type" : "string"
+            },
+            "playedOn" : {
+              "description" : "플레이한 플랫폼",
+              "enum" : [ "Steam", "Switch", "GOG", "Epic Games", "Android" ],
+              "type" : "string"
+            },
+            "rating" : {
+              "description" : "개인적으로 매긴 게임 평점 (0-20 정수)",
+              "maximum" : 20,
+              "minimum" : 0,
+              "type" : "integer"
+            },
+            "shortReview" : {
+              "description" : "플레이 후 한줄평",
               "type" : "string"
             }
           }
         }, {
           "properties" : {
             "id" : {
-              "description" : "장르 식별자",
+              "description" : "작품 식별자",
               "type" : "string"
+            },
+            "imageUrl" : {
+              "description" : "팬아트 작품 이미지 URL\n권한에 따라 다른 형태의 URL이 제공됨\n- 일반 사용자: 1시간 유효한 서명된 URL\n- 작품 등록자: 직접 접근 가능한 URL\n",
+              "format" : "uri",
+              "type" : "string"
+            },
+            "genres" : {
+              "items" : {
+                "$ref" : "#/components/schemas/getArtworks_200_response_items_inner_allOf_genres_inner"
+              },
+              "type" : "array"
+            },
+            "isDraft" : {
+              "description" : "작품의 임시저장 상태 여부",
+              "type" : "boolean"
             }
           },
-          "required" : [ "id" ]
+          "required" : [ "genres", "id", "imageUrl", "isDraft" ]
         } ],
         "example" : {
           "id" : "<nanoid format>",
-          "name" : "Action"
+          "title" : "젤다의 전설: 야생의 숨결",
+          "imageUrl" : "https://example.com/images/botw.jpg",
+          "createdAt" : "2023-05-20T14:45:00Z",
+          "genres" : [ {
+            "id" : "<nanoid format>",
+            "name" : "액션"
+          }, {
+            "id" : "<nanoid format>",
+            "name" : "어드벤처"
+          }, {
+            "id" : "<nanoid format>",
+            "name" : "오픈월드"
+          } ],
+          "playedOn" : "Switch",
+          "rating" : 20,
+          "shortReview" : "광활한 세계와 자유도가 인상적인 걸작",
+          "isDraft" : false
         }
+      },
+      "getArtworks_200_response_metadata" : {
+        "properties" : {
+          "totalCount" : {
+            "description" : "검색 조건에 해당하는 전체 작품 수",
+            "type" : "integer"
+          },
+          "totalPages" : {
+            "description" : "전체 페이지 수 (totalCount와 pageSize 기반으로 계산)",
+            "type" : "integer"
+          },
+          "currentPage" : {
+            "description" : "현재 조회 중인 페이지 번호",
+            "type" : "integer"
+          },
+          "pageSize" : {
+            "description" : "페이지당 항목 수 (고정값)\n* CMS 접근: 10개\n* 일반 접근: 20개\n",
+            "type" : "integer"
+          }
+        },
+        "required" : [ "currentPage", "pageSize", "totalCount", "totalPages" ]
+      },
+      "getArtworks_200_response" : {
+        "properties" : {
+          "items" : {
+            "items" : {
+              "$ref" : "#/components/schemas/getArtworks_200_response_items_inner"
+            },
+            "type" : "array"
+          },
+          "metadata" : {
+            "$ref" : "#/components/schemas/getArtworks_200_response_metadata"
+          }
+        },
+        "required" : [ "items", "metadata" ]
       },
       "uploadArtworkImage_413_response" : {
         "allOf" : [ {
@@ -682,79 +868,6 @@
         },
         "required" : [ "code" ]
       },
-      "getArtworks_200_response_inner" : {
-        "allOf" : [ {
-          "properties" : {
-            "title" : {
-              "description" : "게임 제목",
-              "type" : "string"
-            },
-            "createdAt" : {
-              "description" : "팬아트 작품을 완성한 날짜",
-              "format" : "date-time",
-              "type" : "string"
-            },
-            "playedOn" : {
-              "description" : "플레이한 플랫폼",
-              "enum" : [ "Steam", "Switch", "GOG", "Epic Games", "Android" ],
-              "type" : "string"
-            },
-            "rating" : {
-              "description" : "개인적으로 매긴 게임 평점 (0-20 정수)",
-              "maximum" : 20,
-              "minimum" : 0,
-              "type" : "integer"
-            },
-            "shortReview" : {
-              "description" : "플레이 후 한줄평",
-              "type" : "string"
-            }
-          }
-        }, {
-          "properties" : {
-            "id" : {
-              "description" : "작품 식별자",
-              "type" : "string"
-            },
-            "imageUrl" : {
-              "description" : "팬아트 작품 이미지 URL\n권한에 따라 다른 형태의 URL이 제공됨\n- 일반 사용자: 1시간 유효한 서명된 URL\n- 작품 등록자: 직접 접근 가능한 URL\n",
-              "format" : "uri",
-              "type" : "string"
-            },
-            "genres" : {
-              "items" : {
-                "$ref" : "#/components/schemas/getArtworks_200_response_inner_allOf_genres_inner"
-              },
-              "type" : "array"
-            },
-            "isDraft" : {
-              "description" : "작품의 임시저장 상태 여부",
-              "type" : "boolean"
-            }
-          },
-          "required" : [ "genres", "id", "imageUrl", "isDraft" ]
-        } ],
-        "example" : {
-          "id" : "<nanoid format>",
-          "title" : "젤다의 전설: 야생의 숨결",
-          "imageUrl" : "https://example.com/images/botw.jpg",
-          "createdAt" : "2023-05-20T14:45:00Z",
-          "genres" : [ {
-            "id" : "<nanoid format>",
-            "name" : "액션"
-          }, {
-            "id" : "<nanoid format>",
-            "name" : "어드벤처"
-          }, {
-            "id" : "<nanoid format>",
-            "name" : "오픈월드"
-          } ],
-          "playedOn" : "Switch",
-          "rating" : 20,
-          "shortReview" : "광활한 세계와 자유도가 인상적인 걸작",
-          "isDraft" : false
-        }
-      },
       "uploadArtworkImage_request" : {
         "properties" : {
           "image" : {
@@ -791,6 +904,28 @@
             "message" : "인증에 실패하였습니다"
           }
         } ]
+      },
+      "getArtworks_200_response_items_inner_allOf_genres_inner" : {
+        "allOf" : [ {
+          "properties" : {
+            "name" : {
+              "description" : "장르명",
+              "type" : "string"
+            }
+          }
+        }, {
+          "properties" : {
+            "id" : {
+              "description" : "장르 식별자",
+              "type" : "string"
+            }
+          },
+          "required" : [ "id" ]
+        } ],
+        "example" : {
+          "id" : "<nanoid format>",
+          "name" : "Action"
+        }
       },
       "setup2FA_400_response" : {
         "allOf" : [ {

--- a/openapi/paths/artworks/path.yaml
+++ b/openapi/paths/artworks/path.yaml
@@ -1,18 +1,86 @@
 get:
-  description: 작품 목록 취득
+  description: 작품 목록 조회
   operationId: getArtworks
-  security: []
+  security:
+    - bearerAuth: [] # CMS 프론트엔드에서의 액세스용(인증 필요)
+    - {} # 팬아트 프론트엔드에서의 액세스용(인증 불필요)
   tags:
     - Artworks
+  parameters:
+    - name: page
+      in: query
+      description: (공통) 페이지 번호 (1부터 시작)
+      schema:
+        type: integer
+        minimum: 1
+        default: 1
+    - name: sort
+      in: query
+      description: |
+        (공통) 정렬 기준
+        * created_desc: 최신순
+        * created_asc: 과거순
+        * rating_desc: 평점 높은순
+        * rating_asc: 평점 낮은순
+      schema:
+        type: string
+        enum: [created_desc, created_asc, rating_desc, rating_asc]
+        default: created_desc
+    - name: platforms
+      in: query
+      description: (공통) 플랫폼 필터 (복수 선택 가능)
+      schema:
+        type: array
+        uniqueItems: true
+        items:
+          type: string
+          enum: [Steam, Switch, GOG, Epic Games, Android]
+    - name: genres
+      in: query
+      description: (공통) 장르 필터 (복수 선택 가능)
+      schema:
+        type: array
+        uniqueItems: true
+        items:
+          type: string
+    - name: search
+      in: query
+      description: |
+        (공통) 제목 검색어
+        * 앞뒤 공백은 자동으로 제거됨
+        * 연속된 공백은 단일 공백으로 처리됨
+      schema:
+        type: string
+        minLength: 1
+        maxLength: 50
+    - name: status
+      in: query
+      description: (CMS) 작품 상태 필터 (인증된 요청에서만 사용 가능)
+      schema:
+        type: array
+        items:
+          type: string
+          enum: [draft, published]
+        default: [published]
   responses:
     "200":
-      description: 작품 목록이 반환됨
+      description: 작품 목록 조회 성공
       content:
         application/json:
           schema:
-            type: array
-            items:
-              $ref: "../../components/artworks/response.yaml#/Artwork"
+            $ref: "../../components/artworks/response.yaml#/ArtworkListResponse"
+    "400":
+      description: 잘못된 요청
+      content:
+        application/json:
+          schema:
+            $ref: "../../components/errors/errors.yaml#/BadRequestError"
+    "401":
+      description: 인증 실패
+      content:
+        application/json:
+          schema:
+            $ref: "../../components/errors/errors.yaml#/UnauthorizedError"
 
 post:
   description: 새로운 작품 등록


### PR DESCRIPTION
## 관련 이슈
close #37 

## 작업 내용
작품 목록 조회 api 설계 변경
- security 를 인증/비인증으로 나눠 정의
- 검색/정렬/필터용 파라미터 추가
- 리스폰스에 메타데이터 추가
