### PR TITLE
fix: remove uniqueItems in bodies of delete endpoints

### DIFF
--- a/openapi/output/openapi.json
+++ b/openapi/output/openapi.json
@@ -1221,8 +1221,7 @@
               "type" : "string"
             },
             "minItems" : 1,
-            "type" : "array",
-            "uniqueItems" : true
+            "type" : "array"
           }
         },
         "required" : [ "ids" ]

--- a/openapi/paths/artworks/path.yaml
+++ b/openapi/paths/artworks/path.yaml
@@ -137,7 +137,6 @@ delete:
               items:
                 type: string
               minItems: 1
-              uniqueItems: true
   responses:
     "204":
       description: 모든 작품이 성공적으로 삭제됨

--- a/openapi/paths/genres/path.yaml
+++ b/openapi/paths/genres/path.yaml
@@ -105,7 +105,6 @@ delete:
               items:
                 type: string
               minItems: 1
-              uniqueItems: true
   responses:
     "204":
       description: 모든 장르가 성공적으로 삭제됨


### PR DESCRIPTION
## 관련 이슈
- 

## 작업 내용
- uniqueItems: true 의 설정을 api 정의에서 제거

## 비고
- 클라이언트 생성 시에, 생성되는 리퀘스트의 타입과, 실제 api 처리 상의 코드에 모순이 발생되어, 타입은 set 을 기대하나 실제 처리는 배열로 되어버리는 문제가 발생(https://github.com/OpenAPITools/openapi-generator/issues/14055).
- 따라서, api 사양 및 생성된 코드에서는 set 이 아닌 배열로 생성되게끔 한 후, 실제 사용처인 프론트엔드에서 set 으로 가공 후 api 에 던질 때 배열로 변환하는 방식으로 변경 예정
