### PR TITLE
fix: modify patch request by adding minProperties, instead of using anyOf

### DIFF
--- a/openapi/components/artworks/request.yaml
+++ b/openapi/components/artworks/request.yaml
@@ -60,6 +60,7 @@ UploadArtworkImageRequest:
 # 수정 리퀘스트용 스키마
 UpdateArtworkRequest:
   type: object
+  minProperties: 1
   properties:
     koTitle:
       type: string
@@ -76,8 +77,8 @@ UpdateArtworkRequest:
       description: 팬아트 작품을 완성한 날짜
     playedOn:
       type: string
-      enum: [Steam, Switch, GOG, Epic Games, Android]
       description: 플레이한 플랫폼
+      enum: [Steam, Switch, GOG, Epic Games, Android]
     rating:
       type: integer
       minimum: 0
@@ -97,24 +98,3 @@ UpdateArtworkRequest:
       items:
         type: string
       description: 게임의 장르ID 목록
-  anyOf:
-    - type: object
-      required: [koTitle]
-    - type: object
-      required: [enTitle]
-    - type: object
-      required: [jaTitle]
-    - type: object
-      required: [createdAt]
-    - type: object
-      required: [playedOn]
-    - type: object
-      required: [rating]
-    - type: object
-      required: [koShortReview]
-    - type: object
-      required: [enShortReview]
-    - type: object
-      required: [jaShortReview]
-    - type: object
-      required: [genreIds]

--- a/openapi/components/genres/request.yaml
+++ b/openapi/components/genres/request.yaml
@@ -25,6 +25,7 @@ CreateGenreRequest:
 # 수정 리퀘스트용 스키마
 UpdateGenreRequest:
   type: object
+  minProperties: 1
   properties:
     koName:
       type: string
@@ -41,10 +42,3 @@ UpdateGenreRequest:
       description: 장르의 일본어명
       minLength: 1
       maxLength: 30
-  anyOf:
-    - type: object
-      required: [koName]
-    - type: object
-      required: [enName]
-    - type: object
-      required: [jaName]

--- a/openapi/output/openapi.json
+++ b/openapi/output/openapi.json
@@ -1228,16 +1228,7 @@
         } ]
       },
       "updateGenre_request" : {
-        "anyOf" : [ {
-          "required" : [ "koName" ],
-          "type" : "object"
-        }, {
-          "required" : [ "enName" ],
-          "type" : "object"
-        }, {
-          "required" : [ "jaName" ],
-          "type" : "object"
-        } ],
+        "minProperties" : 1,
         "properties" : {
           "koName" : {
             "description" : "장르의 한국어명",
@@ -1558,37 +1549,7 @@
         "required" : [ "imageKey" ]
       },
       "updateArtwork_request" : {
-        "anyOf" : [ {
-          "required" : [ "koTitle" ],
-          "type" : "object"
-        }, {
-          "required" : [ "enTitle" ],
-          "type" : "object"
-        }, {
-          "required" : [ "jaTitle" ],
-          "type" : "object"
-        }, {
-          "required" : [ "createdAt" ],
-          "type" : "object"
-        }, {
-          "required" : [ "playedOn" ],
-          "type" : "object"
-        }, {
-          "required" : [ "rating" ],
-          "type" : "object"
-        }, {
-          "required" : [ "koShortReview" ],
-          "type" : "object"
-        }, {
-          "required" : [ "enShortReview" ],
-          "type" : "object"
-        }, {
-          "required" : [ "jaShortReview" ],
-          "type" : "object"
-        }, {
-          "required" : [ "genreIds" ],
-          "type" : "object"
-        } ],
+        "minProperties" : 1,
         "properties" : {
           "koTitle" : {
             "description" : "게임 제목(한국어)",


### PR DESCRIPTION
## 관련 이슈
-

## 작업 내용
- anyOf 대신 minProperties 로 부분 수정임을 명시

## 비고
anyOf 로 사용하는 기존 방식의 경우, openapi-generator-cli 상 enum 값이 있을 경우, enum class 를 생성하지 않고 클라이언트를 자동 생성하게 되어, 클라이언트 빌드 시 에러가 발생함.
따라서, 굳이 anyOf 로 지정하지 않고 minProperties 1 을 이용해서 부분 수정임을 명시하는 방식으로 변경.