### PR TITLE
fix: modify series property to inline in artwork response

### DIFF
--- a/openapi/components/artworks/response.yaml
+++ b/openapi/components/artworks/response.yaml
@@ -16,26 +16,6 @@ ArtworkTranslation:
       type: string
       description: 해당 언어의 간단한 리뷰
 
-# 작품 정보에 포함되는 시리즈 참조 정보
-ArtworkSeries:
-  type: object
-  required:
-    - id
-    - order
-    - translations
-  properties:
-    id:
-      type: string
-      description: 시리즈 식별자
-    order:
-      type: integer
-      description: 시리즈 내 순서 (0부터 시작)
-    translations:
-      type: array
-      description: 시리즈 번역 정보
-      items:
-        $ref: "../series/response.yaml#/SeriesTranslation"
-
 # 작품 정보 (모든 번역 포함)
 Artwork:
   type: object
@@ -94,7 +74,22 @@ Artwork:
       type: object
       description: 작품이 속한 시리즈 정보
       nullable: true
-      $ref: "#/ArtworkSeries"
+      required:
+        - id
+        - order
+        - translations
+      properties:
+        id:
+          type: string
+          description: 시리즈 식별자
+        order:
+          type: integer
+          description: 시리즈 내 순서 (0부터 시작)
+        translations:
+          type: array
+          description: 시리즈 번역 정보
+          items:
+            $ref: "../series/response.yaml#/SeriesTranslation"
 
 # 페이지네이션 리스폰스용 스키마
 ArtworkListResponse:


### PR DESCRIPTION
## 관련 이슈
-

## 작업 내용
- 아트워크 시리즈 컴포넌트 삭제 및 리스폰스 인라인화
